### PR TITLE
Add getRemoteVersion() to shock client.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
-VERSION: 0.0.10 (Released 1/26/2015)
+VERSION: 0.0.11 (Released 6/10/2016)
+-----------------------------------------
+
+NEW FEATURES:
+- Added getRemoteVersion() function to the client. This will allow detection
+  of shock upgrades, but more usefully makes a cheap call to shock to ensure
+  it's up.
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- None
+
+VERSION: 0.0.10 (Released 1/26/2016)
 -----------------------------------------
 
 NEW FEATURES:
@@ -7,7 +18,7 @@ NEW FEATURES:
 UPDATED FEATURES / MAJOR BUG FIXES:
 - None
 
-VERSION: 0.0.9 (Released 1/24/2015)
+VERSION: 0.0.9 (Released 1/24/2016)
 -----------------------------------------
 
 NEW FEATURES:

--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,7 @@
     <include name="apache_commons/http/httpclient-4.3.1.jar"/>
     <include name="apache_commons/http/httpcore-4.3.jar"/>
     <include name="apache_commons/http/httpmime-4.3.1.jar"/>
-    <include name="kbase/auth/kbase-auth-0.3.1.jar"/>
+    <include name="kbase/auth/kbase-auth-0.3.2.jar"/>
     <include name="jackson/jackson-annotations-2.2.3.jar"/>
     <include name="jackson/jackson-core-2.2.3.jar"/>
     <include name="jackson/jackson-databind-2.2.3.jar"/>
@@ -92,7 +92,7 @@
     <fail unless="test.pwd2" message="property test.pwd2 not set."/>
     <echo message="starting ${package} tests"/>
     <echo message="testing against jar ${compile.jarfile}.jar"/>
-    <junit failureproperty="test.failed">
+    <junit failureproperty="test.failed" fork="yes">
       <classpath path="${compile.jarfile}.jar"/>
       <classpath refid="compile.classpath"/>
       <formatter type="plain" usefile="false" />

--- a/src/us/kbase/shock/client/test/ShockTests.java
+++ b/src/us/kbase/shock/client/test/ShockTests.java
@@ -1209,4 +1209,10 @@ public class ShockTests {
 		//will throw errors if doesn't accept md5
 		new ShockVersionStamp("e90c05e51aa22e53daec604c815962f3");
 	}
+	
+	@Test
+	public void getRemoteVersion() throws Exception {
+		String v = BSC1.getRemoteVersion();
+		assertThat("incorrect version", Version.valueOf(v), is(VERSION));
+	}
 }


### PR DESCRIPTION
Allows checks for updated shock version since the client was started,
but is also a cheap call to ensure the server is up.

Also fixed ant junit builds as per
https://github.com/MrCreosote/workspace_deluxe/commit/9ae8492d86efbcaf22423e40bdcc22cadd8af19f