### PR TITLE
Add InputStream getFile(), drop support for Shock 0.8.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ See the Javadocs for more information.
 Compatibility
 -------------
 
-Tested against Shock 0.8.23, 0.9.6, 0.9.12, and 0.9.13. Some features are
-unsupported by earlier versions (see the Javadoc).
+Tested against Shock 0.9.6 and 0.9.14.
 
 Build
 -----
@@ -190,7 +189,7 @@ Build:
 Known issues
 ------------
 
-- The filename is not set consistently.
+- The filename is not set consistently with older Shock versions.
 - If a client is created such that it trusts self-signed certificates, all
   future clients will also trust all SSCs regardless of the constructor
   arguments. Similarly, creation of a standard client means that any new

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+VERSION: 0.0.12 (Released 7/3/2016)
+-----------------------------------------
+
+BACKWARDS INCOMPATIBILITIES:
+- Dropped support for 0.8.X Shock versions.
+
+NEW FEATURES:
+- Added a getFile() method that returns an InputStream.
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Setting the filename in the addNode() methods will now work for Shock
+  versions that support it correctly.
+
 VERSION: 0.0.11 (Released 6/10/2016)
 -----------------------------------------
 

--- a/build.xml
+++ b/build.xml
@@ -59,7 +59,7 @@
   <target name="compile" depends="init" description="compile the source">
     <fail unless="compile.jarfile" message="property compile.jarfile not set."/>
     <!-- Compile class files-->
-    <javac destdir="${classes}" includeantruntime="false" target="1.6" source="1.6"
+    <javac destdir="${classes}" includeantruntime="false" target="1.7" source="1.7"
       debug="true" classpathref="compile.classpath">
       <src path="${src}"/>
     </javac>

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -591,8 +591,9 @@ public class BasicShockClient {
 		if (file == null) {
 			throw new IllegalArgumentException("file may not be null");
 		}
-		if (filename == null) {
-			throw new IllegalArgumentException("filename may not be null");
+		if (filename == null || filename.isEmpty()) {
+			throw new IllegalArgumentException(
+					"filename may not be null or empty");
 		}
 		return _addNodeStreaming(null, file, filename, format);
 	}
@@ -623,8 +624,9 @@ public class BasicShockClient {
 		if (file == null) {
 			throw new IllegalArgumentException("file may not be null");
 		}
-		if (filename == null) {
-			throw new IllegalArgumentException("filename may not be null");
+		if (filename == null || filename.isEmpty()) {
+			throw new IllegalArgumentException(
+					"filename may not be null or empty");
 		}
 		return _addNodeStreaming(attributes, file, filename, format);
 	}
@@ -657,7 +659,7 @@ public class BasicShockClient {
 	}
 	
 	private ShockNode _addNodeStreaming(final Map<String, Object> attributes,
-			final InputStream file, final String filename, final String format)
+			final InputStream file, String filename, final String format)
 			throws IOException, ShockHttpException, JsonProcessingException,
 			TokenExpiredException {
 		byte[] b = new byte[CHUNK_SIZE];
@@ -682,9 +684,7 @@ public class BasicShockClient {
 			}
 			// doesn't work in 0.9.6 but doesn't break anything
 			// works in 0.9.12+
-			if (filename != null && !filename.isEmpty()) {
-				mpeb.addTextBody("file_name", filename);
-			}
+			mpeb.addTextBody("file_name", filename);
 			htp.setEntity(mpeb.build());
 			sn = (ShockNode) processRequest(htp, ShockNodeResponse.class);
 		}

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -389,20 +389,12 @@ public class BasicShockClient {
 	 * @throws TokenExpiredException if the client authorization token has
 	 * expired.
 	 */
-	public void getFile(final ShockNode sn, final OutputStream file)
+	public void getFile(final ShockNode sn, final OutputStream os)
 			throws TokenExpiredException, IOException, ShockHttpException {
-		if (sn == null || file == null) {
-			throw new IllegalArgumentException(
-					"Neither the shock node nor the file may be null");
+		if (os == null) {
+			throw new NullPointerException("os");
 		}
-		if (sn.getFileInformation().getSize() == 0) {
-			throw new ShockNoFileException(400, "Node has no file");
-		}
-		final BigDecimal size = new BigDecimal(
-				sn.getFileInformation().getSize());
-		//if there are more than 2^32 chunks we're in big trouble
-		final int chunks = size.divide(new BigDecimal(CHUNK_SIZE))
-				.setScale(0, BigDecimal.ROUND_CEILING).intValueExact();
+		final int chunks = getChunks(sn);
 		final URI targeturl = nodeurl.resolve(sn.getId().getId() +
 				getDownloadURLPrefix());
 		for (int i = 0; i < chunks; i++) {
@@ -414,9 +406,138 @@ public class BasicShockClient {
 				if (code > 299) {
 					getShockData(response, ShockNodeResponse.class); //trigger errors
 				}
-				file.write(EntityUtils.toByteArray(response.getEntity()));
+				os.write(EntityUtils.toByteArray(response.getEntity()));
 			} finally {
 				response.close();
+			}
+		}
+	}
+	private static int getChunks(final ShockNode sn)
+			throws ShockNoFileException {
+		if (sn == null) {
+			throw new NullPointerException("sn");
+		}
+		if (sn.getFileInformation().getSize() == 0) {
+			throw new ShockNoFileException(400, "Node has no file");
+		}
+		final BigDecimal size = new BigDecimal(
+				sn.getFileInformation().getSize());
+		//if there are more than 2^32 chunks we're in big trouble
+		return size.divide(new BigDecimal(CHUNK_SIZE))
+				.setScale(0, BigDecimal.ROUND_CEILING).intValueExact();
+	}
+	
+	/**
+	 * Equivalent to client.getFile(client.getNode(id))
+	 * @param id the ID of the shock node.
+	 * @returns an input stream containing the file.
+	 * @throws IOException if an IO problem occurs.
+	 * @throws ShockHttpException if the file could not be fetched from shock.
+	 * @throws TokenExpiredException if the client authorization token has
+	 * expired.
+	 */
+	public InputStream getFile(final ShockNodeId id)
+			throws IOException, ShockHttpException, TokenExpiredException {
+		return getFile(getNode(id));
+	}
+	
+	/** Get the file for this shock node. The input stream this function
+	 * returns is naturally buffered.
+	 * @param sn the shock node from which to retrieve the file.
+	 * @returns an input stream containing the file.
+	 * @throws IOException if an IO problem occurs.
+	 * @throws ShockHttpException if the file could not be fetched from shock.
+	 * @throws TokenExpiredException if the client authorization token has
+	 * expired.
+	 */
+	public InputStream getFile(final ShockNode sn)
+			throws TokenExpiredException, ShockHttpException, IOException {
+		return new ShockFileInputStream(sn);
+	}
+	
+	private class ShockFileInputStream extends InputStream {
+		
+		private final URI targeturl;
+		private final int chunks;
+		private int chunkCount = 0;
+		private byte[] chunk;
+		private int pos = 0;
+		
+		public ShockFileInputStream(final ShockNode sn)
+				throws TokenExpiredException, ShockHttpException, IOException {
+			chunks = getChunks(sn);
+			targeturl = nodeurl.resolve(sn.getId().getId() +
+					getDownloadURLPrefix());
+			getNextChunk(); // must be at least one
+		}
+		
+		private void getNextChunk() throws TokenExpiredException,
+				IOException, ShockHttpException {
+			if (chunkCount >= chunks) {
+				chunk = null;
+				return;
+			}
+			final HttpGet htg = new HttpGet(targeturl.toString() +
+					(chunkCount + 1));
+			authorize(htg);
+			final CloseableHttpResponse response = client.execute(htg);
+			try {
+				final int code = response.getStatusLine().getStatusCode();
+				if (code > 299) {
+					getShockData(response, ShockNodeResponse.class); //trigger errors
+				}
+				chunk = EntityUtils.toByteArray(response.getEntity());
+				chunkCount++;
+				pos = 0;
+			} finally {
+				response.close();
+			}
+		}
+
+		//TODO NOW TEST all
+		@Override
+		public int read() throws IOException {
+			if (chunk == null) {
+				return -1;
+			}
+			final int i = chunk[pos] & 0xFF;
+			pos++;
+			if (pos >= chunk.length) {
+				getNextChunkWrapExcep();
+			}
+			return i;
+		}
+
+		private void getNextChunkWrapExcep() throws IOException {
+			try {
+				getNextChunk();
+			} catch (TokenExpiredException | ShockHttpException e) {
+				throw new IOException("Couldn't fetch data from Shock: " +
+						e.getMessage(), e);
+			}
+		}
+		
+		//TODO NOW test error checks
+		@Override
+		public int read(byte b[], int off, int len) throws IOException {
+			if (b == null) {
+				throw new NullPointerException();
+			} else if (off < 0 || len < 0 || len > b.length - off) {
+				throw new IndexOutOfBoundsException();
+			} else if (len == 0) {
+				return 0;
+			} else if (chunk == null) {
+				return -1;
+			}
+			if (pos + len >= chunk.length) {
+				System.arraycopy(chunk, pos, b, off, chunk.length - pos);
+				final int size = chunk.length - pos;
+				getNextChunkWrapExcep(); // sets chunk to null
+				return size;
+			} else {
+				System.arraycopy(chunk, pos, b, off, len);
+				pos += len;
+				return len;
 			}
 		}
 	}

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -680,13 +680,11 @@ public class BasicShockClient {
 			if (format != null && !format.isEmpty()) {
 				mpeb.addTextBody("format", format);
 			}
-			// causes an error for 0.8.23, makes node immutable
 			// doesn't work in 0.9.6 but doesn't break anything
-			// works in 0.9.12
-			// TODO Add when 0.8 drops support.
-//			if (filename != null && !filename.isEmpty()) {
-//				mpeb.addTextBody("file_name", filename);
-//			}
+			// works in 0.9.12+
+			if (filename != null && !filename.isEmpty()) {
+				mpeb.addTextBody("file_name", filename);
+			}
 			htp.setEntity(mpeb.build());
 			sn = (ShockNode) processRequest(htp, ShockNodeResponse.class);
 		}

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -494,7 +494,6 @@ public class BasicShockClient {
 			}
 		}
 
-		//TODO NOW TEST all
 		@Override
 		public int read() throws IOException {
 			if (chunk == null) {

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -517,7 +517,6 @@ public class BasicShockClient {
 			}
 		}
 		
-		//TODO NOW test error checks
 		@Override
 		public int read(byte b[], int off, int len) throws IOException {
 			if (b == null) {

--- a/src/us/kbase/shock/client/ShockNode.java
+++ b/src/us/kbase/shock/client/ShockNode.java
@@ -1,6 +1,7 @@
 package us.kbase.shock.client;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
@@ -171,6 +172,21 @@ public class ShockNode extends ShockData {
 			throws ShockHttpException, IOException, TokenExpiredException {
 		checkDeleted();
 		client.getFile(this, file);
+	}
+	
+	/** Proxy for {@link BasicShockClient#getFile(ShockNode)
+	 * getFile()}.
+	 * Gets the file stored at this shock node.
+	 * @return an input stream containing the file.
+	 * @throws ShockHttpException if the file could not be retrieved from shock.
+	 * @throws IOException if an IO problem occurs.
+	 * @throws TokenExpiredException if the client's token has expired.
+	 */
+	@JsonIgnore
+	public InputStream getFile()
+			throws TokenExpiredException, ShockHttpException, IOException {
+		checkDeleted();
+		return client.getFile(this);
 	}
 	
 	/**

--- a/src/us/kbase/shock/client/ShockUserId.java
+++ b/src/us/kbase/shock/client/ShockUserId.java
@@ -25,11 +25,6 @@ public class ShockUserId {
 	
 	// for jackson
 	private ShockUserId() {}
-	// for Shock 0.8.23, Shock 0.9.6 sends full attrib hash
-	//TODO remove when dropping support for 0.8.23
-	private ShockUserId(final String id) {
-		uuid = id;
-	}
 
 	/** Get the user's Shock ID.
 	 * @return the user's ID.
@@ -38,7 +33,7 @@ public class ShockUserId {
 		return uuid;
 	}
 
-	/** Get the username. Null for shock versions < 0.9.
+	/** Get the username.
 	 * @return the username.
 	 */
 	public String getUsername() {

--- a/src/us/kbase/shock/client/test/ShockTests.java
+++ b/src/us/kbase/shock/client/test/ShockTests.java
@@ -26,10 +26,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-//import org.junit.Ignore;
 import org.junit.Test;
 
 import com.gc.iotools.stream.is.InputStreamFromOutputStream;
@@ -64,7 +64,6 @@ public class ShockTests {
 	
 	private static BasicShockClient BSC1;
 	private static BasicShockClient BSC2;
-//	private static BasicShockClient bscNoAuth;
 	private static AuthUser USER2;
 	
 	private static ShockUserId USER1_SID;
@@ -139,7 +138,6 @@ public class ShockTests {
 					ioe.getLocalizedMessage());
 		}
 		VERSION = Version.valueOf(BSC1.getShockVersion());
-//		bscNoAuth = new BasicShockClient(url);
 		System.out.println("Set up shock clients for Shock version " +
 				BSC1.getShockVersion());
 		USER1_SID = BSC1.addNode().getACLs().getOwner();
@@ -309,6 +307,10 @@ public class ShockTests {
 		} catch (ShockNodeDeletedException snde) {}
 		try {
 			sn.getFile(new ByteArrayOutputStream());
+			fail("Method ran on deleted node");
+		} catch (ShockNodeDeletedException snde) {}
+		try {
+			sn.getFile();
 			fail("Method ran on deleted node");
 		} catch (ShockNodeDeletedException snde) {}
 		try {
@@ -499,49 +501,70 @@ public class ShockTests {
 //		assertThat("filename correct", sn.getFileInformation().getName(),
 //				is(filename));
 		assertThat("format correct", sn.getFileInformation().getFormat(), is(format));
-		System.out.println("ID " + id + " Verifying " + filesize + "b file... ");
+		System.out.println("ID " + id + " Verifying " + filesize + "b file via outputstream... ");
 
 		OutputStreamToInputStream<String> osis =
 				new OutputStreamToInputStream<String>() {
 					
 			@Override
 			protected String doRead(InputStream is) throws Exception {
-				byte[] data = new byte[readlen];
-				int read = read(is, data);
-				long size = 0;
-				long reads = 1;
-				while (reads <= writes) {
-					assertThat("file incorrect at pos " + size, 
-							new String(data, StandardCharsets.UTF_8),
-							is(string));
-					size += read;
-					reads++;
-					read = read(is, data);
-				}
-				byte[] finaldata = new byte[finallen];
-				int read2 = read(is, finaldata);
-				assertThat("correct length of final string for node "
-						+ sn.getId().getId(), read + read2, is(finallen));
-				byte[] lastgot = new byte[read + read2];
-				System.arraycopy(data, 0, lastgot, 0, read);
-				System.arraycopy(finaldata, 0, lastgot, read, read2);
-				if (finallen > 0) {
-					final String l = new String(lastgot, StandardCharsets.UTF_8);
-					assertThat("file incorrect at last pos " + size, l, is(last));
-					size += read + read2;
-				}
-				data = new byte[1];
-				if (is.read(data) > 0) {
-					fail("file is too long");
-				}
-				assertThat("correct file size for node " + sn.getId().getId(),
-						size, is(filesize));
+				verifyStreamedNode(sn, string, writes, last, is);
 				return null;
 			}
+
+
 		};
 		BSC1.getFile(sn, osis);
 		osis.close();
 		System.out.println("\tID " + id + " Verifying done.");
+		
+		System.out.println("ID " + id + " Verifying " + filesize + "b file via inputstream... ");
+		InputStream is = BSC1.getFile(sn);
+		verifyStreamedNode(sn, string, writes, last, is);
+		is.close();
+	}
+	
+	private void verifyStreamedNode(
+			final ShockNode sn,
+			final String string,
+			final long writes,
+			final String last,
+			final InputStream is)
+			throws IOException {
+		final int readlen = string.getBytes(StandardCharsets.UTF_8).length;
+		final int finallen = last.getBytes(StandardCharsets.UTF_8).length;
+		final long filesize = readlen * writes + finallen;
+		byte[] data = new byte[readlen];
+		int read = read(is, data);
+		long size = 0;
+		long reads = 1;
+		while (reads <= writes) {
+			assertThat("file incorrect at pos " + size, 
+					new String(data, StandardCharsets.UTF_8),
+					is(string));
+			size += read;
+			assertThat("read size correct", read, is(readlen));
+			reads++;
+			read = read(is, data);
+		}
+		byte[] finaldata = new byte[finallen];
+		int read2 = read(is, finaldata);
+		assertThat("correct length of final string for node "
+				+ sn.getId().getId(), read + read2, is(finallen));
+		byte[] lastgot = new byte[read + read2];
+		System.arraycopy(data, 0, lastgot, 0, read);
+		System.arraycopy(finaldata, 0, lastgot, read, read2);
+		if (finallen > 0) {
+			final String l = new String(lastgot, StandardCharsets.UTF_8);
+			assertThat("file incorrect at last pos " + size, l, is(last));
+			size += read + read2;
+		}
+		data = new byte[1];
+		if (is.read(data) > 0) {
+			fail("file is too long");
+		}
+		assertThat("correct file size for node " + sn.getId().getId(),
+				size, is(filesize));
 	}
 	
 	private int read(final InputStream file, final byte[] b)
@@ -622,23 +645,32 @@ public class ShockTests {
 	private void testFile(String content, String name, String format, ShockNode sn)
 			throws Exception {
 		ShockNode snget = BSC1.getNode(sn.getId());
+		String utf8 = StandardCharsets.UTF_8.name();
+		
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		BSC1.getFile(sn, bos);
-		String filecon1 = bos.toString(StandardCharsets.UTF_8.name());
+		String filecon1 = bos.toString(utf8);
 		
 		bos = new ByteArrayOutputStream();
 		BSC1.getFile(sn.getId(), bos);
-		String filecon2 = bos.toString(StandardCharsets.UTF_8.name());
+		String filecon2 = bos.toString(utf8);
 		
 		bos = new ByteArrayOutputStream();
 		snget.getFile(bos);
-		String filefromnode = bos.toString(StandardCharsets.UTF_8.name());
+		String filefromnode = bos.toString(utf8);
+		
+		 
+		String filecon1is = IOUtils.toString(BSC1.getFile(sn), utf8);
+		String filecon2is = IOUtils.toString(BSC1.getFile(sn.getId()), utf8);
+		String filefromnodeIs = IOUtils.toString(sn.getFile(), utf8);
+		
 		Set<String> digestTypes = snget.getFileInformation().getChecksumTypes();
 		assertTrue("has md5", digestTypes.contains("md5"));
 		assertThat("unequal md5", snget.getFileInformation().getChecksum("md5"),
 				is(DigestUtils.md5Hex(content)));
 		try {
-			snget.getFileInformation().getChecksum("this is not a checksum type");
+			snget.getFileInformation().getChecksum(
+					"this is not a checksum type");
 			fail("got checksum type that doesn't exist");
 		} catch (IllegalArgumentException iae) {
 			assertThat("exception string incorrect", 
@@ -649,6 +681,12 @@ public class ShockTests {
 				is(filecon1));
 		assertThat("files from the 2 polymorphic getFile() methods different",
 				filecon1, is(filecon2));
+		assertThat("files from node w/ input & outputstreams differ",
+				filefromnode, is(filefromnodeIs));
+		assertThat("inpustream: file from node != file from client",
+				filefromnodeIs, is(filecon1is));
+		assertThat("inputstream: files from the 2 polymorphic getFile() methods different",
+				filecon1is, is(filecon2is));
 		assertThat("file content unequal", filecon1, is(content));
 		assertThat("file name unequal", snget.getFileInformation().getName(),
 				is(name));
@@ -682,19 +720,40 @@ public class ShockTests {
 		try {
 			sn.getFile(null);
 			fail("called get file w/ null arg");
-		} catch (IllegalArgumentException ioe) {
+		} catch (NullPointerException ioe) {
 			assertThat("no file exc string incorrect", ioe.getLocalizedMessage(), 
-					is("Neither the shock node nor the file may be null"));
+					is("os"));
+		}
+		try {
+			sn.getFile();
+			fail("Got file from node w/o file");
+		} catch (ShockNoFileException snfe) {
+			assertThat("no file exc string incorrect", snfe.getLocalizedMessage(), 
+					is("Node has no file"));
 		}
 		try {
 			BSC1.getFile((ShockNode) null, new ByteArrayOutputStream());
 			fail("called get file w/ null arg");
-		} catch (IllegalArgumentException iae) {
+		} catch (NullPointerException iae) {
 			assertThat("no file exc string incorrect", iae.getLocalizedMessage(), 
-					is("Neither the shock node nor the file may be null"));
+					is("sn"));
+		}
+		try {
+			BSC1.getFile((ShockNode) null);
+			fail("called get file w/ null arg");
+		} catch (NullPointerException iae) {
+			assertThat("no file exc string incorrect", iae.getLocalizedMessage(), 
+					is("sn"));
 		}
 		try {
 			BSC1.getFile(sn, new ByteArrayOutputStream());
+			fail("Got file from node w/o file");
+		} catch (ShockNoFileException snfe) {
+			assertThat("no file exc string incorrect", snfe.getLocalizedMessage(), 
+					is("Node has no file"));
+		}
+		try {
+			BSC1.getFile(sn);
 			fail("Got file from node w/o file");
 		} catch (ShockNoFileException snfe) {
 			assertThat("no file exc string incorrect", snfe.getLocalizedMessage(), 
@@ -708,7 +767,21 @@ public class ShockTests {
 					is("id may not be null"));
 		}
 		try {
+			BSC1.getFile((ShockNodeId) null);
+			fail("called get file w/ null arg");
+		} catch (NullPointerException npe) {
+			assertThat("no file exc string incorrect", npe.getLocalizedMessage(), 
+					is("id may not be null"));
+		}
+		try {
 			BSC1.getFile(sn.getId(), new ByteArrayOutputStream());
+			fail("Got file from node w/o file");
+		} catch (ShockNoFileException snfe) {
+			assertThat("no file exc string incorrect", snfe.getLocalizedMessage(), 
+					is("Node has no file"));
+		}
+		try {
+			BSC1.getFile(sn.getId());
 			fail("Got file from node w/o file");
 		} catch (ShockNoFileException snfe) {
 			assertThat("no file exc string incorrect", snfe.getLocalizedMessage(), 
@@ -717,9 +790,9 @@ public class ShockTests {
 		try {
 			BSC1.getFile(sn, null);
 			fail("called get file w/ null arg");
-		} catch (IllegalArgumentException ioe) {
+		} catch (NullPointerException ioe) {
 			assertThat("no file exc string incorrect", ioe.getLocalizedMessage(), 
-					is("Neither the shock node nor the file may be null"));
+					is("os"));
 		}
 		sn.delete();
 		
@@ -728,6 +801,12 @@ public class ShockTests {
 		BSC1.deleteNode(sn.getId());
 		try {
 			BSC1.getFile(sn, new ByteArrayOutputStream());
+		} catch (ShockNoNodeException snne) {
+			assertThat("correct exception message", snne.getLocalizedMessage(),
+					is("Node not found"));
+		}
+		try {
+			BSC1.getFile(sn);
 		} catch (ShockNoNodeException snne) {
 			assertThat("correct exception message", snne.getLocalizedMessage(),
 					is("Node not found"));

--- a/src/us/kbase/shock/client/test/ShockTests.java
+++ b/src/us/kbase/shock/client/test/ShockTests.java
@@ -495,6 +495,29 @@ public class ShockTests {
 		/* test reading files one byte at a time, which is not exercised by
 		 * the other tests.
 		 */
+		
+		// won't get new chunk
+		ShockNode sn = writeFileToNode(null, "aaaaaaaaaa", 4999999,
+				"abcdefghij", "foo", "UTF-8", 1);
+		InputStream is = sn.getFile();
+		byte[] b = new byte[49999990];
+		is.read(b);
+		int offset = 97; //a in ascii
+		for (int i = 0; i < 10; i++) {
+			assertThat("incorrect read", is.read(), is(i + offset));
+		}
+		assertThat("incorrect read", is.read(), is(-1));
+		
+		// will get new 1 byte chunk
+		sn = writeFileToNode(null, "aaaaaaaaaa", 4999999,
+				"abcdefghijk", "foo", "UTF-8", 1);
+		is = sn.getFile();
+		b = new byte[49999990];
+		is.read(b);
+		for (int i = 0; i < 11; i++) {
+			assertThat("incorrect read", is.read(), is(i + offset));
+		}
+		assertThat("incorrect read", is.read(), is(-1));
 	}
 	
 	@Test

--- a/src/us/kbase/shock/client/test/ShockTests.java
+++ b/src/us/kbase/shock/client/test/ShockTests.java
@@ -554,12 +554,12 @@ public class ShockTests {
 		verifyStreamedNode(sn, attribs, sb.toString(), minwrites, sbs, "filename", "JSON", 1);
 		sn.delete();
 		
-		sn = writeFileToNode(null, sb.toString(), minwrites, sbs + "~", "filename", null, 2);
-		verifyStreamedNode(sn, null, sb.toString(), minwrites, sbs + "~", "filename", null, 2);
+		sn = writeFileToNode(null, sb.toString(), minwrites, sbs + "~", "a", null, 2);
+		verifyStreamedNode(sn, null, sb.toString(), minwrites, sbs + "~", "a", null, 2);
 		sn.delete();
 		
-		sn = writeFileToNode(null, sb.toString(), minwrites, sbs + ch2, "filename", "", 3);
-		verifyStreamedNode(sn, null, sb.toString(), minwrites, sbs + ch2, "filename", null, 3);
+		sn = writeFileToNode(null, sb.toString(), minwrites, sbs + ch2, "b", "", 3);
+		verifyStreamedNode(sn, null, sb.toString(), minwrites, sbs + ch2, "b", null, 3);
 		sn.delete();
 		
 		sn = writeFileToNode(attribs, sb.toString(), minwrites * 2, sbs2 + "j", "filename", "", 4);
@@ -924,7 +924,14 @@ public class ShockTests {
 			fail("called addNode with null value");
 		} catch (IllegalArgumentException npe) {
 			assertThat("npe message incorrect", npe.getMessage(),
-					is("filename may not be null"));
+					is("filename may not be null or empty"));
+		}
+		try {
+			addNode(BSC1, "foo", "", "foo");
+			fail("called addNode with null value");
+		} catch (IllegalArgumentException npe) {
+			assertThat("npe message incorrect", npe.getMessage(),
+					is("filename may not be null or empty"));
 		}
 		try {
 			addNode(BSC1, null, "foo", "foo", "foo");
@@ -945,7 +952,14 @@ public class ShockTests {
 			fail("called addNode with null value");
 		} catch (IllegalArgumentException npe) {
 			assertThat("npe message incorrect", npe.getMessage(),
-					is("filename may not be null"));
+					is("filename may not be null or empty"));
+		}
+		try {
+			addNode(BSC1, attribs, "foo", "", null);
+			fail("called addNode with null value");
+		} catch (IllegalArgumentException npe) {
+			assertThat("npe message incorrect", npe.getMessage(),
+					is("filename may not be null or empty"));
 		}
 	}
 	


### PR DESCRIPTION
Dropping 0.8.X means the client can set the filename without risking locking the node. Setting the filename doesn't work in older shock versions (0.9.6 at least).