### PR TITLE
get / set public read on node, more

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public class TryShock {
 				ShockACLType.READ);
 		System.out.println(acl1.getRead());
 		
-		ShockACL acl2 = c.getACLs(sn2.getId(), ShockACLType.READ);
+		ShockACL acl2 = c.getACLs(sn2.getId());
 		System.out.println(acl2.getRead());
 		
 		sn2.delete();

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ Build:
 Known issues
 ------------
 
-- The filename is not set consistently with older Shock versions.
 - If a client is created such that it trusts self-signed certificates, all
   future clients will also trust all SSCs regardless of the constructor
   arguments. Similarly, creation of a standard client means that any new

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+VERSION: 0.0.13 (Released 7/7/2016)
+-----------------------------------------
+NEW FEATURES:
+- TBD
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Setting the filename in the addNode() methods will now work for supported
+  Shock versions (0.9.6 and up).
+- The input stream returned by getFile()'s close method now prevents further
+  reads and releases any data cached in memory for garbage collection.
+
 VERSION: 0.0.12 (Released 7/3/2016)
 -----------------------------------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,12 @@
 VERSION: 0.0.13 (Released 7/7/2016)
 -----------------------------------------
+
+BACKWARDS INCOMPATIBILIES:
+- removed the getACLs(ShockNodeId, ShockAclType) method. Use
+  getACLs(ShockNodeId).
+
 NEW FEATURES:
-- TBD
+- Added methods for setting and getting a node's public readability.
 
 UPDATED FEATURES / MAJOR BUG FIXES:
 - Setting the filename in the addNode() methods will now work for supported

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -656,7 +656,6 @@ public class BasicShockClient {
 						ContentType.APPLICATION_JSON, ATTRIBFILE);
 			}
 			if (file != null) {
-				//TODO test filename works
 				mpeb.addBinaryBody("upload", file, ContentType.DEFAULT_BINARY,
 						filename);
 			}
@@ -695,9 +694,6 @@ public class BasicShockClient {
 			if (format != null && !format.isEmpty()) {
 				mpeb.addTextBody("format", format);
 			}
-			// doesn't work in 0.9.6 but doesn't break anything
-			// works in 0.9.12+
-			mpeb.addTextBody("file_name", filename);
 			htp.setEntity(mpeb.build());
 			sn = (ShockNode) processRequest(htp, ShockNodeResponse.class);
 		}
@@ -720,7 +716,7 @@ public class BasicShockClient {
 			final HttpPut htp = new HttpPut(targeturl);
 			final MultipartEntityBuilder mpeb = MultipartEntityBuilder.create();
 			mpeb.addTextBody("parts", "close");
-			//TODO set filename here & test with 0.9.6
+			mpeb.addTextBody("file_name", filename);
 			htp.setEntity(mpeb.build());
 			sn = (ShockNode) processRequest(htp, ShockNodeResponse.class);
 		}

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -644,6 +644,7 @@ public class BasicShockClient {
 						ContentType.APPLICATION_JSON, ATTRIBFILE);
 			}
 			if (file != null) {
+				//TODO test filename works
 				mpeb.addBinaryBody("upload", file, ContentType.DEFAULT_BINARY,
 						filename);
 			}
@@ -707,6 +708,7 @@ public class BasicShockClient {
 			final HttpPut htp = new HttpPut(targeturl);
 			final MultipartEntityBuilder mpeb = MultipartEntityBuilder.create();
 			mpeb.addTextBody("parts", "close");
+			//TODO set filename here & test with 0.9.6
 			htp.setEntity(mpeb.build());
 			sn = (ShockNode) processRequest(htp, ShockNodeResponse.class);
 		}

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -462,6 +462,7 @@ public class BasicShockClient {
 		private int chunkCount = 0;
 		private byte[] chunk;
 		private int pos = 0;
+		private boolean closed = false;
 		
 		public ShockFileInputStream(final ShockNode sn)
 				throws TokenExpiredException, ShockHttpException, IOException {
@@ -470,7 +471,6 @@ public class BasicShockClient {
 					getDownloadURLPrefix());
 			getNextChunk(); // must be at least one
 		}
-		//TODO add close() method, throw exception on read if closed
 		private void getNextChunk() throws TokenExpiredException,
 				IOException, ShockHttpException {
 			if (chunkCount >= chunks) {
@@ -496,6 +496,9 @@ public class BasicShockClient {
 
 		@Override
 		public int read() throws IOException {
+			if (closed) {
+				throw new IOException("Stream is closed.");
+			}
 			if (chunk == null) {
 				return -1;
 			}
@@ -518,6 +521,9 @@ public class BasicShockClient {
 		
 		@Override
 		public int read(byte b[], int off, int len) throws IOException {
+			if (closed) {
+				throw new IOException("Stream is closed.");
+			}
 			if (b == null) {
 				throw new NullPointerException();
 			} else if (off < 0 || len < 0 || len > b.length - off) {
@@ -537,6 +543,12 @@ public class BasicShockClient {
 				pos += len;
 				return len;
 			}
+		}
+		
+		@Override
+		public void close() {
+			closed = true;
+			chunk = null;
 		}
 	}
 	

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -470,7 +470,7 @@ public class BasicShockClient {
 					getDownloadURLPrefix());
 			getNextChunk(); // must be at least one
 		}
-		
+		//TODO add close() method, throw exception on read if closed
 		private void getNextChunk() throws TokenExpiredException,
 				IOException, ShockHttpException {
 			if (chunkCount >= chunks) {

--- a/src/us/kbase/shock/client/ShockACL.java
+++ b/src/us/kbase/shock/client/ShockACL.java
@@ -25,7 +25,6 @@ public class ShockACL extends ShockData {
 	private List<ShockUserId> read;
 	private List<ShockUserId> write;
 	private List<ShockUserId> delete;
-	//may do something with this later. For now just for compatibility.
 	@JsonProperty("public")
 	private Map<String, Boolean> public_;
 	
@@ -67,6 +66,10 @@ public class ShockACL extends ShockData {
 	public List<ShockUserId> getDelete() {
 		if (delete == null) {return null;}
 		return new ArrayList<ShockUserId>(delete);
+	}
+	
+	public boolean isPublicallyReadable() {
+		return public_.get(ShockACLType.READ.getType());
 	}
 	
 	@Override

--- a/src/us/kbase/shock/client/ShockFileInformation.java
+++ b/src/us/kbase/shock/client/ShockFileInformation.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author gaprice@lbl.gov
  *
  */
-@JsonIgnoreProperties({"virtual", "virtual_parts", "created_on"})
+// as of 7/7/16 - may be more now
+//@JsonIgnoreProperties({"virtual", "virtual_parts", "created_on"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ShockFileInformation {
 	
 	private ShockFileInformation(){}

--- a/src/us/kbase/shock/client/ShockNode.java
+++ b/src/us/kbase/shock/client/ShockNode.java
@@ -103,21 +103,19 @@ public class ShockNode extends ShockData {
 		return client.getACLs(getId());
 	}
 	
-	/**
-	 * Proxy for {@link BasicShockClient#getACLs(ShockNodeId, ShockACLType)
-	 * getACLs()}.
-	 * Returns the requested access control list (ACL) for the node.
-	 * @param acl the type of ACL to retrive from shock.
-	 * @return an ACL.
-	 * @throws ShockHttpException if the shock server cannot retrieve the ACL.
+	/** Proxy for {@link BasicShockClient#setPubliclyReadable(ShockNodeId,
+	 * boolean)}.
+	 * @param publicRead true to set publicly readable, false to set private.
+	 * @return the new ACLs.
+	 * @throws ShockHttpException if the ACL could not be modified.
 	 * @throws IOException if an IO problem occurs.
 	 * @throws TokenExpiredException if the client's token has expired.
 	 */
 	@JsonIgnore
-	public ShockACL getACLs(final ShockACLType acl) throws ShockHttpException,
-			IOException, TokenExpiredException {
+	public ShockACL setPubliclyReadable(final boolean publicRead)
+			throws TokenExpiredException, ShockHttpException, IOException {
 		checkDeleted();
-		return client.getACLs(getId(), acl);
+		return client.setPubliclyReadable(getId(), publicRead);
 	}
 	
 	/**
@@ -127,7 +125,7 @@ public class ShockNode extends ShockData {
 	 * @param users the users to which permissions shall be granted.
 	 * @param aclType the ACL(s) to which the users shall be added.
 	 * @return the new ACL.
-	 * @throws ShockHttpException if the read ACL could not be modified.
+	 * @throws ShockHttpException if the ACL could not be modified.
 	 * @throws IOException if an IO problem occurs.
 	 * @throws TokenExpiredException if the client's token has expired.
 	 */

--- a/src/us/kbase/shock/client/ShockNode.java
+++ b/src/us/kbase/shock/client/ShockNode.java
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 
-// TODO just ignore all unknown - do this for all classes. 
 // Don't need these and they're undocumented so ignore for now.
 // last modified is a particular pain since null is represented as '-' so you
 // can't just deserialize to a Date
-@JsonIgnoreProperties({"relatives", "type", "indexes", "tags", "linkages",
-	"linkage", "expiration", "parts", "created_on", "last_modified", "public",
-	"version_parts"})
+//@JsonIgnoreProperties({"relatives", "type", "indexes", "tags", "linkages",
+//	"linkage", "expiration", "parts", "created_on", "last_modified", "public",
+//	"version_parts"}) - as of 7/7/16. Might be more now.
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ShockNode extends ShockData {
 
 	private Map<String, Object> attributes;

--- a/src/us/kbase/shock/client/ShockNode.java
+++ b/src/us/kbase/shock/client/ShockNode.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author gaprice@lbl.gov
  *
  */
+
+// TODO just ignore all unknown - do this for all classes. 
 // Don't need these and they're undocumented so ignore for now.
 // last modified is a particular pain since null is represented as '-' so you
 // can't just deserialize to a Date

--- a/src/us/kbase/shock/client/test/ShockTests.java
+++ b/src/us/kbase/shock/client/test/ShockTests.java
@@ -199,6 +199,7 @@ public class ShockTests {
 		BSC1.updateToken(null);
 		try {
 			BSC1.addNode();
+			fail("Added node with no token");
 		} catch (ShockAuthorizationException sae) {
 			assertThat("correct exception message", sae.getLocalizedMessage(),
 					is("No Authorization"));
@@ -467,6 +468,9 @@ public class ShockTests {
 		assertThat("incorrect read", new String(b, 0, 4, "UTF-8"), is("wee!"));
 		assertThat("incorrect read length", is.read(b, 0, 1), is(-1));
 		
+		is = sn.getFile();
+		is.close();
+		failRead(is, b, 0, 1, new IOException("Stream is closed."));
 		
 	}
 	
@@ -474,6 +478,7 @@ public class ShockTests {
 			Exception exp) {
 		try {
 			is.read(b, off, len);
+			fail("read successfully but expected fail");
 		} catch (Exception got) {
 			assertExceptionCorrect(got, exp);
 		}
@@ -518,6 +523,16 @@ public class ShockTests {
 			assertThat("incorrect read", is.read(), is(i + offset));
 		}
 		assertThat("incorrect read", is.read(), is(-1));
+		
+		is = sn.getFile();
+		is.close();
+		try {
+			is.read();
+			fail("Read successfully but expected fail");
+		} catch (IOException e) {
+			assertThat("incorrect exception message", e.getMessage(),
+					is("Stream is closed."));
+		}
 	}
 	
 	@Test
@@ -890,12 +905,14 @@ public class ShockTests {
 		BSC1.deleteNode(sn.getId());
 		try {
 			BSC1.getFile(sn, new ByteArrayOutputStream());
+			fail("got deleted file");
 		} catch (ShockNoNodeException snne) {
 			assertThat("correct exception message", snne.getLocalizedMessage(),
 					is("Node not found"));
 		}
 		try {
 			BSC1.getFile(sn);
+			fail("got deleted file");
 		} catch (ShockNoNodeException snne) {
 			assertThat("correct exception message", snne.getLocalizedMessage(),
 					is("Node not found"));

--- a/src/us/kbase/shock/client/test/TryShock.java
+++ b/src/us/kbase/shock/client/test/TryShock.java
@@ -49,7 +49,7 @@ public class TryShock {
 				ShockACLType.READ);
 		System.out.println(acl1.getRead());
 		
-		ShockACL acl2 = c.getACLs(sn2.getId(), ShockACLType.READ);
+		ShockACL acl2 = c.getACLs(sn2.getId());
 		System.out.println(acl2.getRead());
 		
 		sn2.delete();


### PR DESCRIPTION
* Add methods to set or get the public read state on nodes.
* Setting the filename now works consistently on supported Shock versions.
* Implemented the close() method for the InputStream returned by getFile().
* Removed the getACLs(ShockNodeId, ShockACLType) method.