### PR TITLE
Optionally return the same node on copy if the user already owns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+VERSION: 0.0.16 (Released 3/3/2019)
+-----------------------------------------
+
+NEW FEATURES:
+- Added the copyNode function.
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Fix a bug getting ACLs from a read-only node.
+
 VERSION: 0.0.15 (Released 2/3/2017)
 -----------------------------------------
 

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -709,11 +709,11 @@ public class BasicShockClient {
 		final ShockNode source = getNode(id);
 		/* So it's possible to construct a token where the name is not the correct name for
 		 * the token. In this case though, the user is just screwing themselves because at 
-		 * this point all that'll happen is they'll make a copy when they didn't want to, since
-		 * the line above already guarantees they can read the node.
+		 * this point all that'll happen is they'll make a copy when they didn't want to or
+		 * vice versa, since the line above already guarantees they can read the node.
 		 */
 		if (unlessAlreadyOwned &&
-				getACLs(source.getId()).getOwner().getUsername().equals(token.getUserName())) {
+				source.getACLs().getOwner().getUsername().equals(token.getUserName())) {
 			return source;
 		}
 		final HttpPost htp = new HttpPost(nodeurl);

--- a/src/us/kbase/shock/client/BasicShockClient.java
+++ b/src/us/kbase/shock/client/BasicShockClient.java
@@ -695,15 +695,27 @@ public class BasicShockClient {
 		return pos;
 	}
 	
-	//TODO NOW unlessAlreadyOwned boolean just returns same node
 	/** Makes a copy of a shock node, including the indexes and attributes, owned by the user.
 	 * @param id the ID of the shock node to copy.
-	 * @return the new shock node.
+	 * @param unlessAlreadyOwned if true and the shock node is already owned by the user,
+	 * don't make a copy.
+	 * @return the new shock node, or the node from the id if unlessAlreadyOwned is true and
+	 * the user already owns the node.
 	 * @throws ShockHttpException if a Shock exception occurs.
 	 * @throws IOException if an IO exception occurs.
 	 */
-	public ShockNode copyNode(final ShockNodeId id) throws ShockHttpException, IOException {
+	public ShockNode copyNode(final ShockNodeId id, final boolean unlessAlreadyOwned)
+			throws ShockHttpException, IOException {
 		final ShockNode source = getNode(id);
+		/* So it's possible to construct a token where the name is not the correct name for
+		 * the token. In this case though, the user is just screwing themselves because at 
+		 * this point all that'll happen is they'll make a copy when they didn't want to, since
+		 * the line above already guarantees they can read the node.
+		 */
+		if (unlessAlreadyOwned &&
+				getACLs(source.getId()).getOwner().getUsername().equals(token.getUserName())) {
+			return source;
+		}
 		final HttpPost htp = new HttpPost(nodeurl);
 		final MultipartEntityBuilder mpeb = MultipartEntityBuilder.create();
 		mpeb.addTextBody("copy_data", id.getId());
@@ -837,8 +849,7 @@ public class BasicShockClient {
 	 */
 	public ShockACL getACLs(final ShockNodeId id)
 			throws IOException, ShockHttpException {
-		final URI targeturl = nodeurl.resolve(id.getId() +
-				ShockACLType.ALL.getUrlFragmentForAcl() + "?verbosity=full");
+		final URI targeturl = nodeurl.resolve(id.getId() + "/acl/?verbosity=full");
 		final HttpGet htg = new HttpGet(targeturl);
 		return (ShockACL) processRequest(htg, ShockACLResponse.class);
 	}


### PR DESCRIPTION
Also fix a bug re getting ACLs when requested by a non-owner. For some
reason `GET ...<node>/acl` and `GET ../<node>/acl/all` are treated
differently by Shock. The former works and the latter fails when the
user has only read permissions to the node.